### PR TITLE
Feature/bimap refactor

### DIFF
--- a/src/Chingon.chpl
+++ b/src/Chingon.chpl
@@ -104,7 +104,7 @@ With symmetric version
      */
      proc init(X: []) {
        super.init(X);
-       this.D = {X.domain.dim(1), X.domain.dim(2)};
+//       this.D = {X.domain.dim(1), X.domain.dim(2)}; //NOT NECESSARY BECAUSE OF super.init(X)
   //     this.loadX(X);
      }
 
@@ -129,9 +129,9 @@ With symmetric version
       */
      proc init(X:[], name: string, directed: bool = false, bipartite: bool = false) {
        super.init(X);
-       this.D = {X.domain.dim(1), X.domain.dim(2)};
+  //     this.D = {X.domain.dim(1), X.domain.dim(2)};
        this.name = name;
-  //     this.loadX(X);
+  //     this.loadX(X);  //NOT NECESSARY IF YOU INITIALIZE THE PARENT CLASS
      }
 
      /*
@@ -140,21 +140,26 @@ With symmetric version
       */
      proc init(X:[], directed: bool) {
        super.init(X);
-       this.D = {X.domain.dim(1), X.domain.dim(2)};
+  //     this.D = {X.domain.dim(1), X.domain.dim(2)};
        this.directed = directed;
   //     this.loadX(X);
      }
 
     /*
      */
+    proc init(X:[], vnames) {
+      super.init(X, vnames);
+      this.verts = this.rows.uni(this.cols);
+    }
+
     proc init(X:[], directed=bool, name: string, vnames: [] string) {
-      super.init(X);
-      this.D = {X.domain.dim(1), X.domain.dim(2)};
+      this.init(X, vnames);
+  //    this.D = {X.domain.dim(1), X.domain.dim(2)};
       this.name = name;
       this.directed=directed;
-      try! this.setRowNames(vnames);
-      try! this.setColNames(vnames);
-      this.verts = this.rows.uni(this.cols);
+//      try! this.setRowNames(vnames);
+  //    try! this.setColNames(vnames);
+    //  this.verts = this.rows.uni(this.cols);
       /*
       for j in 1..vnames.size {
         this.verts.add(vnames[j]);
@@ -167,10 +172,10 @@ With symmetric version
     }
 
     proc init(N: NamedMatrix) {
-      super.init(N.X);
-      this.verts = super.rows.uni(super.cols);
-      this.uVerts = super.rows;
-      this.vVerts = super.cols;
+      super.init(N);
+      this.verts = this.rows.uni(this.cols);
+      this.uVerts = this.rows;
+      this.vVerts = this.cols;
 //      this.loadX(N.X);
     }
   }

--- a/src/Chingon.chpl
+++ b/src/Chingon.chpl
@@ -104,6 +104,7 @@ With symmetric version
      */
      proc init(X: []) {
        super.init(X);
+       this.initDone();
 //       this.D = {X.domain.dim(1), X.domain.dim(2)}; //NOT NECESSARY BECAUSE OF super.init(X)
   //     this.loadX(X);
      }
@@ -112,16 +113,16 @@ With symmetric version
      Constructor using just vertex names.  Good for things like `DAGS <https://en.wikipedia.org/wiki/Directed_acyclic_graph>`_
 
 :arg vnames string []: Array of string names
-      */
+      */ /*
      proc init(vnames: [] string) {
-       super.init();
-       this.D = {1..vnames.size, 1..vnames.size};
-       this.SD = CSRDomain(D);
-       this.X = [SD] real;
+       var D = {1..vnames.size, 1..vnames.size};
+       var SD = CSRDomain(D);
+       var X = [SD] real;
+       super.init(X,vnames);
        for j in 1..vnames.size {
          this.verts.add(vnames[j]);
        }
-     }
+     }*/
 
      /*
      :arg W real []: Array or Matrix representing edges in the graph
@@ -129,6 +130,7 @@ With symmetric version
       */
      proc init(X:[], name: string, directed: bool = false, bipartite: bool = false) {
        super.init(X);
+       this.initDone();
   //     this.D = {X.domain.dim(1), X.domain.dim(2)};
        this.name = name;
   //     this.loadX(X);  //NOT NECESSARY IF YOU INITIALIZE THE PARENT CLASS
@@ -140,6 +142,7 @@ With symmetric version
       */
      proc init(X:[], directed: bool) {
        super.init(X);
+       this.initDone();
   //     this.D = {X.domain.dim(1), X.domain.dim(2)};
        this.directed = directed;
   //     this.loadX(X);
@@ -149,6 +152,7 @@ With symmetric version
      */
     proc init(X:[], vnames) {
       super.init(X, vnames);
+      this.initDone();
       this.verts = this.rows.uni(this.cols);
     }
 

--- a/test/bimap-refactor-test.chpl
+++ b/test/bimap-refactor-test.chpl
@@ -1,0 +1,39 @@
+use LinearAlgebra,
+    LinearAlgebra.Sparse,
+    Chingon;
+
+/* MERGE WITH chingon-base-test.chpl ONCE REFACTORED
+   BRANCH IS MERGED WITH DEVELOP.
+*/
+
+    var nv: int = 8,
+        D: domain(2) = {1..nv, 1..nv},
+        SD: sparse subdomain(D),
+        X: [SD] real;
+
+    var vn: [1..0] string;
+    vn.push_back("star lord");
+    vn.push_back("gamora");
+    vn.push_back("groot");
+    vn.push_back("drax");
+    vn.push_back("rocket");
+    vn.push_back("mantis");
+    vn.push_back("yondu");
+    vn.push_back("nebula");
+
+    writeln(vn);
+
+    SD += (1,2); X[1,2] = 1;
+    SD += (1,3); X[1,3] = 1;
+    SD += (1,4); X[1,4] = 1;
+    SD += (2,2); X[2,2] = 1;
+    SD += (2,4); X[2,4] = 1;
+    SD += (3,4); X[3,4] = 1;
+    SD += (4,5); X[4,5] = 1;
+    SD += (5,6); X[5,6] = 1;
+    SD += (6,7); X[6,7] = 1;
+    SD += (6,8); X[6,8] = 1;
+    SD += (7,8); X[7,8] = 1;
+
+
+    

--- a/test/named-refactor-test.chpl
+++ b/test/named-refactor-test.chpl
@@ -2,74 +2,8 @@ use LinearAlgebra,
     LinearAlgebra.Sparse,
     Chingon;
 
-/*
-    class BiMap {
-      var keys: domain(string),
-          ids:  [keys] int,
-          idxkey: domain(int),
-          idx: [idxkey] string;
-
-
-      Create an empty BiMap.
-
-      proc init() {
-        super.init();
-      }
-
-      proc uni(b: BiMap) {
-        this.keys += b.keys;
-        this.ids += b.ids;
-        this.idxkey += b.idxkey;
-        this.idx += b.idx;
-        return this;
-      }
-    }
-
-    class NamedMatrix {
-      var D: domain(2),
-          SD = CSRDomain(D),
-          X: [SD] real,  // the actual data
-          rows: BiMap = new BiMap(),
-          cols: BiMap = new BiMap();
-
-       proc init() {
-         super.init();
-       }
-
-       proc init(X) {
-         this.D = {X.domain.dim(1), X.domain.dim(2)};
-         super.init();
-         this.loadX(X);
-       }
-    }
-
-    proc NamedMatrix.loadX(X:[], shape: 2*int =(-1,-1)) {
-      if shape(1) > 0 && shape(2) > 0 {
-        this.D = {1..shape(1), 1..shape(2)};
-      }
-      for (i,j) in X.domain {
-        this.SD += (i,j);
-        this.X(i,j) = X(i,j);
-      }
-    }
-
-    class Graph: NamedMatrix {
-      var name: string,
-          directed: bool = false,
-          bipartite: bool = false,
-          verts: BiMap = new BiMap(),
-          uVerts: BiMap = new BiMap(),
-          vVerts: BiMap = new BiMap();
-
-
-      proc init(N: NamedMatrix) {
-        super.init(N.X);
-        this.verts = super.rows.uni(super.cols);
-        this.uVerts = super.rows;
-        this.vVerts = super.cols;
-  //      this.loadX(N.X);
-          }
-        }
+/* MERGE WITH chingon-base-test.chpl ONCE REFACTORED
+   BRANCH IS MERGED WITH DEVELOP.
 */
 
     var nv: int = 8,
@@ -101,12 +35,13 @@ use LinearAlgebra,
     SD += (6,8); X[6,8] = 1;
     SD += (7,8); X[7,8] = 1;
 
-  //  var nm = new NamedMatrix(X=X);
-//    writeln(nm.X.domain);
+    var nm = new NamedMatrix(X=X, names = vn);
+    writeln(nm.rows.keys);
 
 
-
-    var g = new Graph(X = X, directed = false, name = "test graph", vnames = vn);
+  //  var g = new Graph(X = X, vnames = vn);
+//    var g = new Graph(X = X, directed = false, name = "test graph", vnames = vn);
+    var g = new Graph(N = nm);
     writeln(g.name);
     writeln(g.verts.keys);
     writeln(g.verts.ids);


### PR DESCRIPTION
Similar changes as done to `NumSuch`. Tree structure to the `.init`s. `this.loadX(X)` wasn't necessary for most`.init`s. initialized any inherited fields via `super` rather than `this`. add an `init` for building `Graph`s directly from `NamedMatrix` objects. some minor tweaks to adhere to new protocol in latest chapel language update